### PR TITLE
Fix Witchery Issue

### DIFF
--- a/src/main/java/betterquesting/questing/QuestInstance.java
+++ b/src/main/java/betterquesting/questing/QuestInstance.java
@@ -208,6 +208,7 @@ public class QuestInstance implements IQuest
 
     @Override
     public boolean canClaimBasically(EntityPlayer player) {
+        if (DimensionManager.getProvider(player.dimension).getClass().getName().toLowerCase().contains("dreamworld")) return false;
         UUID pID = QuestingAPI.getQuestingUUID(player);
         NBTTagCompound entry = getCompletionInfo(pID);
 


### PR DESCRIPTION
Fix issue where the player may have been able to claim quest rewards in the dream world of witchery, bypassing its special inventory system.